### PR TITLE
add communication to cringe for autotune and crate init

### DIFF
--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -165,7 +165,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.updateStatusBar(d)
                 self.observeTab.handleStatusUpdate(d)
                 self.observeWindow.handleStatusUpdate(d)
-                self._setGuiRunning(d["Running"], d["SourceName"])
+                self._setGuiRunning(d["Running"])
                 self.triggerTab.updateRecordLengthsFromServer(d["Nsamples"], d["Npresamp"])
                 self.workflowTab.handleStatusUpdate(d)
 

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -915,7 +915,10 @@ class MainWindow(QtWidgets.QMainWindow):
         print("crateStartAndAutotune")
         if not self.sourceIsRunning:
             print("starting lancero")
-            self._start() # _startLancero wont set self.sourceIsTDM
+            success = self._start() # _startLancero wont set self.sourceIsTDM
+            if not success:
+                print("failed to start lancero, return early from crateStartAndAutotune")
+                return
             wait_ms = 500
         else:
             print("lancero already started, not starting")

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -900,7 +900,7 @@ class MainWindow(QtWidgets.QMainWindow):
         except zmq.Again:
             message = f"Socket timeout, timeout = {cringe.RCVTIMEO/1000} s" 
             print(message)
-        if not reply.startswith("ok"):
+        if not message.startswith("ok"):
             resultBox = QtWidgets.QMessageBox(self)
             resultBox.setText(f"Cringe Control Error\ncommand={command}\n{message}")
             resultBox.setWindowTitle("Cringe Control Error")

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -916,10 +916,12 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.startStopButton.text == "Start data":
             print("starting lancero")
             self._start() # _startLancero wont set self.sourceIsTDM
+            wait_ms = 2000
         else:
             print("lancero already started, not starting")
-        # pause?
-        self._cringeCommand("FULL_TUNE")
+            wait_ms = 0
+        # wait a bit for dastard to get the lancero souce setup, then run full tune
+        QtCore.QTimer.singleShot(wait_ms, lambda: self._cringeCommand("FULL_TUNE"))
 
 
 class HostPortDialog(QtWidgets.QDialog):

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -913,7 +913,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def crateStartAndAutotune(self):
         print("crateStartAndAutotune")
-        if self.sourceIsRunning:
+        if not self.sourceIsRunning:
             print("starting lancero")
             self._start() # _startLancero wont set self.sourceIsTDM
             wait_ms = 500

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -898,10 +898,12 @@ class MainWindow(QtWidgets.QMainWindow):
             reply = cringe.recv().decode() # this blocks until cringe replies, or until RCVTIMEO
             print(f"reply `{reply}` from cringe")
             message = f"reply={reply}"
+            success = True
         except zmq.Again:
             message = f"Socket timeout, timeout = {cringe.RCVTIMEO/1000} s" 
             print(message)
-        if not message.startswith("ok"):
+            success = False
+        if not success:
             resultBox = QtWidgets.QMessageBox(self)
             resultBox.setText(f"Cringe Control Error\ncommand={command}\n{message}")
             resultBox.setWindowTitle("Cringe Control Error")

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -75,7 +75,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.pushButton_sendExperimentStateLabel.clicked.connect(self.sendExperimentStateLabel)
         self.pushButton_pauseExperimental.clicked.connect(self.handlePauseExperimental)
         self.pushButton_unpauseExperimental.clicked.connect(self.handleUnpauseExperimental)
-        self.running = False
+        self.sourceIsRunning = False
         self.sourceIsTDM = False
         self.cols = 0
         self.rows = 0
@@ -334,7 +334,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if mb <= 0:
             # No data is okay...unless server says it's running!
-            if self.running:
+            if self.sourceIsRunning:
                 self.statusFreshLabel.setText("no fresh data")
                 color("white", bg="red")
             else:
@@ -575,7 +575,7 @@ class MainWindow(QtWidgets.QMainWindow):
     @pyqtSlot()
     def startStop(self):
         """Slot to handle pressing the Start/Stop data button."""
-        if self.running:
+        if self.sourceIsRunning:
             okay = self._stop()
             self._setGuiRunning(False)
             # I think we want to do this even if stop failed, because it's usually due to an already stopped source?
@@ -592,8 +592,8 @@ class MainWindow(QtWidgets.QMainWindow):
         print("Stopping Data")
         return True
 
-    def _setGuiRunning(self, running, sourceName=""):
-        self.running = running
+    def _setGuiRunning(self, running):
+        self.sourceIsRunning = running
         label = "Start Data"
         if running:
             label = "Stop Data"
@@ -913,10 +913,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def crateStartAndAutotune(self):
         print("crateStartAndAutotune")
-        if self.startStopButton.text == "Start data":
+        if self.sourceIsRunning:
             print("starting lancero")
             self._start() # _startLancero wont set self.sourceIsTDM
-            wait_ms = 2000
+            wait_ms = 500
         else:
             print("lancero already started, not starting")
             wait_ms = 0

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -70,6 +70,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actionLoad_Projectors_Basis.triggered.connect(self.loadProjectorsBasis)
         self.actionLoad_Mix.triggered.connect(self.loadMix)
         self.actionPop_out_Observe.triggered.connect(self.popOutObserve)
+        self.actionTDM_Autotune.triggered.connect(self.crateStartAndAutotune)
         self.pushButton_sendEdgeMulti.clicked.connect(self.sendEdgeMulti)
         self.pushButton_sendMix.clicked.connect(self.sendMix)
         self.pushButton_sendExperimentStateLabel.clicked.connect(self.sendExperimentStateLabel)
@@ -887,7 +888,7 @@ class MainWindow(QtWidgets.QMainWindow):
         ctx = zmq.Context() # just create a new context each time so we dont need to keep track of it
         cringe = ctx.socket(zmq.REQ)
         cringe.LINGER = 0 # ms
-        cringe.RCVTIMEO = 10*1000 # ms
+        cringe.RCVTIMEO = 30*1000 # ms
         cringe_addr = f"tcp://{cringe_address}:{cringe_port}"
         cringe.connect(cringe_addr)
         print(f"connect to cringe at {cringe_addr}")   

--- a/dastardcommander/rpc_client.py
+++ b/dastardcommander/rpc_client.py
@@ -60,7 +60,7 @@ class JSONClient(object):
                 print(message)
             if errorBox and self.qtParent is not None:
                 resultBox = QtWidgets.QMessageBox(self.qtParent)
-                resultBox.setText(message)
+                resultBox.setText("DASTARD RPC Error\n"+message)
                 resultBox.setWindowTitle("DASTARD RPC Error")
                 # The above line doesn't work on mac, from qt docs "On macOS, the window
                 # title is ignored (as required by the macOS Guidelines)."

--- a/dastardcommander/ui/dc.ui
+++ b/dastardcommander/ui/dc.ui
@@ -1262,6 +1262,7 @@
     <addaction name="actionLoad_Projectors_Basis"/>
     <addaction name="actionLoad_Mix"/>
     <addaction name="actionPop_out_Observe"/>
+    <addaction name="actionTDM_Autotune"/>
    </widget>
    <addaction name="menuConnection"/>
    <addaction name="menuExpert"/>
@@ -1290,6 +1291,11 @@
   <action name="actionPop_out_Observe">
    <property name="text">
     <string>Pop out Observe</string>
+   </property>
+  </action>
+  <action name="actionTDM_Autotune">
+   <property name="text">
+    <string>TDM Autotune</string>
    </property>
   </action>
  </widget>

--- a/dastardcommander/ui/dc.ui
+++ b/dastardcommander/ui/dc.ui
@@ -537,13 +537,6 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="2" column="0">
-                    <widget class="QCheckBox" name="checkBox_lanceroAutoRestart">
-                     <property name="text">
-                      <string>Auto Restart (not working)</string>
-                     </property>
-                    </widget>
-                   </item>
                   </layout>
                  </item>
                 </layout>
@@ -603,6 +596,32 @@
                 </size>
                </property>
               </spacer>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="gridLayoutWidget">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>340</y>
+              <width>171</width>
+              <height>111</height>
+             </rect>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_5">
+             <item row="0" column="0">
+              <widget class="QPushButton" name="pushButton_initializeCrate">
+               <property name="text">
+                <string>Initalize Crate</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QPushButton" name="pushButton_startAndAutotune">
+               <property name="text">
+                <string>Start and Autotune</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>


### PR DESCRIPTION
Adds 2 buttons to lancero source, one that runs crate init, and another that runs autotune. Also adds an entry in the expert menu for autotune.