### PR TITLE
Update writing.ui

### DIFF
--- a/dastardcommander/ui/writing.ui
+++ b/dastardcommander/ui/writing.ui
@@ -129,6 +129,9 @@
      </item>
      <item row="1" column="0">
       <widget class="QCheckBox" name="checkBox_LJH3">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
         <string>LJH3</string>
        </property>


### PR DESCRIPTION
Two groups have accidentally written ljh3 files recently, and since there is no software to analyze them, its just a mistake. Disable the button for now so we can avoid this mistake and deal with it later if we ever actually want to use ljh3 files.