### PR TITLE
Phase unwrap: fix broken GUI elements

### DIFF
--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -212,10 +212,12 @@ class MainWindow(QtWidgets.QMainWindow):
         quietTopics = set(
             ["TRIGGERRATE", "NUMBERWRITTEN", "EXTERNALTRIGGER", "DATADROP"]
         )  # add "ALIVE"
-        if topic not in quietTopics or self.nmsg < 15:
+        _suppress_after_number = 20
+        if topic not in quietTopics or self.nmsg <= _suppress_after_number:
             print("%s %5d: %s" % (topic, self.nmsg, d))
-        if self.nmsg == 21:
-            print("After message #20, suppressing {} messages.".format(quietTopics))
+        if self.nmsg == _suppress_after_number + 1:
+            note = f"After message #{_suppress_after_number}, suppressing {quietTopics} messages."
+            print(note)
 
         if topic == "ALIVE":
             self.heartbeat(d)

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -641,6 +641,11 @@ class MainWindow(QtWidgets.QMainWindow):
             self.__dict__["udpPort%d" % id].setValue(port)
 
     def fillPhaseResetInfo(self, d):
+        self.unwrapBiasCheck.setChecked(d["Bias"])
+        if d["PulseSign"] >= 0:
+            self.phasePosPulses.setChecked(True)
+        else:
+            self.phaseNegPulses.setChecked(True)
         self.phaseResetSamplesBox.setValue(d["ResetAfter"])
         unwrap, dropBits = d["Unwrap"], d["RescaleRaw"]
         if unwrap and dropBits:

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -646,6 +646,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.phasePosPulses.setChecked(True)
         else:
             self.phaseNegPulses.setChecked(True)
+        self.updateBiasText()
         self.phaseResetSamplesBox.setValue(d["ResetAfter"])
         unwrap, dropBits = d["Unwrap"], d["RescaleRaw"]
         if unwrap and dropBits:


### PR DESCRIPTION
We were not updating the GUI checkbox "Biased unwrapping" and the radio button for positive/negative-going pulses. When the ABACO message arrived, the relevant values weren't used to set these. Must have been an oversight.

Fixes #114