### PR TITLE
Make disabled channel list work with Simple Triggers

### DIFF
--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -274,7 +274,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             elif topic == "TRIGGER":
                 self.triggerTab.handleTriggerMessage(d)
-                self.triggerTabSimple.handleTriggerMessage(d, self.nmsg)
+                self.triggerTabSimple.handleTriggerMessage(d)
 
             elif topic == "GROUPTRIGGER":
                 self.triggerTab.handleGroupTriggerMessage(d)

--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -154,6 +154,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.last_messages = defaultdict(str)
         self.channel_names = []
         self.channel_prefixes = set()
+        self.channel_indices = {}  # a map from channel number to index
+        self.triggerTabSimple.channel_indices = self.channel_indices
         self.triggerTab.channel_names = self.channel_names
         self.observeTab.channel_names = self.channel_names
         self.observeWindow.channel_names = self.channel_names
@@ -320,10 +322,14 @@ class MainWindow(QtWidgets.QMainWindow):
             elif topic == "CHANNELNAMES":
                 self.channel_names[:] = []  # Careful: don't replace the variable
                 self.channel_prefixes.clear()
-                for name in d:
+                self.channel_indices.clear()  # a map from channel numbers to indices
+                for index, name in enumerate(d):
                     self.channel_names.append(name)
                     prefix = name.rstrip("1234567890")
                     self.channel_prefixes.add(prefix)
+                    if prefix == "chan":
+                        number = int(name[len(prefix):])
+                        self.channel_indices[number] = index
                 print("New channames: ", self.channel_names)
                 if self.sourceIsTDM:
                     self.triggerTab.channelChooserBox.setCurrentIndex(2)

--- a/dastardcommander/observe.py
+++ b/dastardcommander/observe.py
@@ -345,25 +345,29 @@ class CountRateMap(QtWidgets.QWidget):
         button.setFlat(False)
         button.chanName = name
         button.chanIndex = len(self.buttons)
-        button.clicked.connect(lambda: self.click_callback(name))
+        button.chanNumber = None
+        button.clicked.connect(lambda: self.click_callback(button))
         button.setToolTip(tooltip)
         button.triggers_blocked = False
         self.buttons.append(button)
         self.named_buttons[name] = button
         try:
             chnum = int(name.replace("chan", ""))
+            button.chanNumber = chnum
             if chnum in self.triggerBlocker.blocked:
                 self.setButtonDisabled(name)
         except ValueError:
             pass
 
     @pyqtSlot()
-    def click_callback(self, name):
-        chan = int(name.replace("chan", ""))
-        self.triggerBlocker.toggle_channel(chan)
-        if chan in self.triggerBlocker.blocked:
+    def click_callback(self, button):
+        name = button.chanName
+        cnum = button.chanNumber
+        self.triggerBlocker.toggle_channel(cnum)
+        if cnum in self.triggerBlocker.blocked:
             print(f"Channel {name} triggering is disabled.")
             self.setButtonDisabled(name)
+            self.owner.block_channel.emit(button.chanIndex)
         else:
             print(f"Channel {name} triggering is enabled.")
             self.setButtonEnabled(name)
@@ -384,7 +388,6 @@ class CountRateMap(QtWidgets.QWidget):
         if "DISABLED" not in tt:
             tt = "[DISABLED] " + tt
             button.setToolTip(tt)
-        self.owner.block_channel.emit(button.chanIndex)
 
     def setButtonEnabled(self, name):
         button = self.named_buttons.get(name, None)

--- a/dastardcommander/trigger_config.py
+++ b/dastardcommander/trigger_config.py
@@ -223,7 +223,10 @@ class TriggerConfig(QtWidgets.QWidget):
                     self.trigger_state[c] = newstate
         return allstates
 
-    def configureDastardTriggers(self):
+    def configureDastardTriggers(self, singlestate=None):
+        if singlestate is not None:
+            self.client.call("SourceControl.ConfigureTriggers", singlestate)
+            return
         for state in self.alltriggerstates():
             self.client.call("SourceControl.ConfigureTriggers", state)
 
@@ -362,7 +365,8 @@ class TriggerConfig(QtWidgets.QWidget):
         notrig_state["AutoTrigger"] = False
         notrig_state["EdgeTrigger"] = False
         notrig_state["LevelTrigger"] = False
-        self.configureDastardTriggers()
+        notrig_state["EMTState"]={"EdgeMulti": False, "EdgeMultiNoise": False}
+        self.configureDastardTriggers(notrig_state)
 
     def handleGroupTriggerMessage(self, msg):
         """Handle the group trigger state message"""

--- a/dastardcommander/trigger_config_simple.py
+++ b/dastardcommander/trigger_config_simple.py
@@ -211,12 +211,15 @@ class TriggerConfigSimple(QtWidgets.QWidget):
         if not exclude_blocked:
             return signal_channels
         sigset = set(signal_channels)
-        enabledchan = list(sigset - set(self.triggerBlocker.blocked))
+        blocked_numbers = self.triggerBlocker.blocked
+        blocked_indices = [self.channel_indices[n] for n in blocked_numbers]
+        enabledchan = list(sigset - set(blocked_indices))
         if len(enabledchan) < len(sigset):
             print("{}/{} channels enabled and {} disabled: {}".format(len(enabledchan), 
-                len(sigset), len(sigset)-len(enabledchan), self.triggerBlocker.blocked))
+                len(sigset), len(sigset)-len(enabledchan), blocked_indices))
         else:
-            print("All {} channels are enabled.".format(len(enabledchan)))
+            print("All {} channels are enabled; .".format(len(enabledchan)))
+            print("The disabled list is: ", blocked_indices)
         enabledchan.sort()
         return enabledchan
 

--- a/dastardcommander/trigger_config_simple.py
+++ b/dastardcommander/trigger_config_simple.py
@@ -71,6 +71,7 @@ class TriggerConfigSimple(QtWidgets.QWidget):
         self.comboBox_twoTriggers.currentIndexChanged.connect(self.handleUIChange)
         self.pushButton_sendPulse.clicked.connect(self.handleSendPulse)
         self.pushButton_sendNoise.clicked.connect(self.handleSendNoise)
+        self.pushButton_sendNone.clicked.connect(self.zeroAllTriggers)
         self.toolButton_chooseProjectors.clicked.connect(self.handleChooseProjectors)
         self.pushButton_sendProjectors.clicked.connect(self.handleSendProjectors)
 
@@ -99,7 +100,9 @@ class TriggerConfigSimple(QtWidgets.QWidget):
         config = {
             "ChannelIndices": self.channelIndicesSignalOnlyWithExcludes(),
             "AutoTrigger": True,
+            "AutoDelay": 0,
         }
+        print("Sending noise! To ", config["ChannelIndices"])
         self.client.call("SourceControl.ConfigureTriggers", config)
         self._lastSentConfig = config
         self._lastSentConfigTime = time.time()

--- a/dastardcommander/trigger_config_simple.py
+++ b/dastardcommander/trigger_config_simple.py
@@ -200,10 +200,13 @@ class TriggerConfigSimple(QtWidgets.QWidget):
     def channelIndicesSignalOnlyWithExcludes(self):
         sigchan = set(self.dcom.channelIndicesSignalOnly())
         enabledchan = list(sigchan - set(self.triggerBlocker.blocked))
+        if len(enabledchan) < len(sigchan):
+            print("{}/{} channels enabled and {} disabled: {}".format(len(enabledchan), 
+                len(sigchan), len(sigchan)-len(enabledchan), self.triggerBlocker.blocked))
         enabledchan.sort()
         return enabledchan
 
-    def handleTriggerMessage(self, d, nmsg):
+    def handleTriggerMessage(self, d):
         """If DASTARD indicates the trigger state has changed, change the UI to say so."""
         # we assume any TRIGGER message more than 100 ms after this class changed the trigger settings
         # has changed the state

--- a/dastardcommander/trigger_config_simple.py
+++ b/dastardcommander/trigger_config_simple.py
@@ -207,21 +207,21 @@ class TriggerConfigSimple(QtWidgets.QWidget):
         If `exclude_blocked` is true, also exclude any listed in the self.triggerBlocker.blocked
         list of disabled channels.
         """
-        signal_channels = self.dcom.channelIndicesSignalOnly()
+        signal_indices = self.dcom.channelIndicesSignalOnly()
         if not exclude_blocked:
-            return signal_channels
-        sigset = set(signal_channels)
+            return signal_indices
+        sigset = set(signal_indices)
         blocked_numbers = self.triggerBlocker.blocked
         blocked_indices = [self.channel_indices[n] for n in blocked_numbers]
-        enabledchan = list(sigset - set(blocked_indices))
-        if len(enabledchan) < len(sigset):
-            print("{}/{} channels enabled and {} disabled: {}".format(len(enabledchan), 
-                len(sigset), len(sigset)-len(enabledchan), blocked_indices))
+        enabled_indices = list(sigset - set(blocked_indices))
+        if len(enabled_indices) < len(sigset):
+            print("{}/{} channels enabled and {} disabled: {}".format(len(enabled_indices), 
+                len(sigset), len(sigset)-len(enabled_indices), blocked_indices))
         else:
-            print("All {} channels are enabled; .".format(len(enabledchan)))
+            print("All {} channels are enabled; .".format(len(enabled_indices)))
             print("The disabled list is: ", blocked_indices)
-        enabledchan.sort()
-        return enabledchan
+        enabled_indices.sort()
+        return enabled_indices
 
     def handleTriggerMessage(self, d):
         """If DASTARD indicates the trigger state has changed, change the UI to say so."""

--- a/dastardcommander/ui/trigger_config_simple.ui
+++ b/dastardcommander/ui/trigger_config_simple.ui
@@ -316,7 +316,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QPushButton" name="pushButton">
+       <widget class="QPushButton" name="pushButton_sendNone">
         <property name="text">
          <string>Send</string>
         </property>

--- a/dastardcommander/ui/trigger_config_simple.ui
+++ b/dastardcommander/ui/trigger_config_simple.ui
@@ -254,7 +254,7 @@
      <property name="frameShape">
       <enum>QFrame::Panel</enum>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <layout class="QGridLayout" name="gridLayout">
       <property name="leftMargin">
        <number>2</number>
       </property>
@@ -267,7 +267,7 @@
       <property name="bottomMargin">
        <number>2</number>
       </property>
-      <item>
+      <item row="0" column="0">
        <widget class="QLabel" name="label_20">
         <property name="font">
          <font>
@@ -283,7 +283,7 @@
         </property>
        </widget>
       </item>
-      <item>
+      <item row="0" column="1">
        <widget class="QPushButton" name="pushButton_sendNoise">
         <property name="minimumSize">
          <size>
@@ -297,6 +297,26 @@
           <height>0</height>
          </size>
         </property>
+        <property name="text">
+         <string>Send</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Turn Off All Triggers&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::AutoText</enum>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="pushButton">
         <property name="text">
          <string>Send</string>
         </property>


### PR DESCRIPTION
Make the standard (simple) trigger tab work with the list of disabled channels, i.e., don't turn on noise or pulse triggers for them. The bug was in using channel numbers instead of their index from 0. Also make the whole Dcom not start up and send commands to the Dastard server to turn off the disabled channels. They should already be off, and if not, Dcom should be a passive observer.
Fixes #121.