### PR TITLE
GUI element to limit max # of records to write

### DIFF
--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -41,7 +41,7 @@ from . import projectors
 from . import observe
 from . import workflow
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 # Here is how you try to import compiled UI files and fall back to processing them
 # at load time via PyQt5.uic. But for now, with frequent changes, let's process all

--- a/dastardcommander/ui/dc.ui
+++ b/dastardcommander/ui/dc.ui
@@ -1578,13 +1578,13 @@
       </widget>
       <widget class="QWidget" name="tabTriggeringSimple">
        <attribute name="title">
-        <string>Legacy Triggering</string>
+        <string>New Triggering</string>
        </attribute>
        <layout class="QHBoxLayout" name="horizontalLayout_9"/>
       </widget>
       <widget class="QWidget" name="tabTriggering">
        <attribute name="title">
-        <string>New Triggering</string>
+        <string>Classic Triggering</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_9"/>
       </widget>

--- a/dastardcommander/ui/dc.ui
+++ b/dastardcommander/ui/dc.ui
@@ -1578,13 +1578,13 @@
       </widget>
       <widget class="QWidget" name="tabTriggeringSimple">
        <attribute name="title">
-        <string>Triggering</string>
+        <string>Legacy Triggering</string>
        </attribute>
        <layout class="QHBoxLayout" name="horizontalLayout_9"/>
       </widget>
       <widget class="QWidget" name="tabTriggering">
        <attribute name="title">
-        <string>Advanced Triggering</string>
+        <string>New Triggering</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_9"/>
       </widget>
@@ -1830,7 +1830,7 @@
      <x>0</x>
      <y>0</y>
      <width>718</width>
-     <height>37</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuConnection">

--- a/dastardcommander/ui/writing.ui
+++ b/dastardcommander/ui/writing.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>707</width>
-    <height>348</height>
+    <height>351</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -117,7 +117,7 @@
    </item>
    <item>
     <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0">
+     <item row="0" column="1">
       <widget class="QCheckBox" name="checkBox_LJH22">
        <property name="text">
         <string>LJH22</string>
@@ -127,20 +127,34 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_LJH22">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff2600;&quot;&gt;Not writing&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="checkBox_OFF">
+       <property name="text">
+        <string>OFF </string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_OFF">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff2600;&quot;&gt;Not writing&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QCheckBox" name="checkBox_LJH3">
        <property name="enabled">
         <bool>false</bool>
        </property>
        <property name="text">
         <string>LJH3</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="checkBox_OFF">
-       <property name="text">
-        <string>OFF </string>
        </property>
       </widget>
      </item>

--- a/dastardcommander/ui/writing.ui
+++ b/dastardcommander/ui/writing.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>707</width>
-    <height>303</height>
+    <height>348</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -147,20 +147,110 @@
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="label_numberWritten">
-     <property name="text">
-      <string>Records Written: none</string>
+    <layout class="QHBoxLayout" name="maxRecordsLayout">
+     <item>
+      <widget class="QCheckBox" name="enableStopAtN">
+       <property name="toolTip">
+        <string>Enable stop writing after the given number of records</string>
+       </property>
+       <property name="text">
+        <string>Enable stop at N records</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="stopAtNRecords">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>If enabled, stop writing after this many records written</string>
+       </property>
+       <property name="suffix">
+        <string> records</string>
+       </property>
+       <property name="maximum">
+        <number>99999999</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label_numberWritten">
+       <property name="text">
+        <string>Records Written: none</string>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
      </property>
-     <property name="textInteractionFlags">
-      <set>Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
+    </spacer>
    </item>
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>enableStopAtN</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>stopAtNRecords</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>473</x>
+     <y>276</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>627</x>
+     <y>276</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/dastardcommander/writing.py
+++ b/dastardcommander/writing.py
@@ -73,12 +73,15 @@ class WritingControl(QtWidgets.QWidget):
 
     def handleNumberWritten(self, d):
         Nwritten = np.sum(d["NumberWritten"])
-        self.label_numberWritten.setText("Number Written Total: {}\nNumber Written by Channel: {}".format(
-            Nwritten, d["NumberWritten"]))
+        written_message = f"{Nwritten}"
         if self.stopAtNRecords.isEnabled():
             Nmax = self.stopAtNRecords.value()
+            pct = Nwritten*100.0/Nmax
+            written_message += f" ({pct:.2f}% of the automatic shutoff value)"
             if Nmax > 0 and Nwritten >= Nmax and self.writing:
                 self.stop()
+        self.label_numberWritten.setText("Number Written Total: {}\nNumber Written by Channel: {}".format(
+            written_message, d["NumberWritten"]))
 
     def start(self):
         if self.writing:

--- a/dastardcommander/writing.py
+++ b/dastardcommander/writing.py
@@ -65,8 +65,13 @@ class WritingControl(QtWidgets.QWidget):
             self.updatePath(result)
 
     def handleNumberWritten(self, d):
+        Nwritten = np.sum(d["NumberWritten"])
         self.label_numberWritten.setText("Number Written Total: {}\nNumber Written by Channel: {}".format(
-            np.sum(d["NumberWritten"]), d["NumberWritten"]))
+            Nwritten, d["NumberWritten"]))
+        if self.stopAtNRecords.isEnabled():
+            Nmax = self.stopAtNRecords.value()
+            if Nmax > 0 and Nwritten >= Nmax and self.writing:
+                self.stop()
 
     def start(self):
         if self.writing:

--- a/dastardcommander/writing.py
+++ b/dastardcommander/writing.py
@@ -1,5 +1,6 @@
 # Qt5 imports
 import PyQt5.uic
+from PyQt5.QtCore import pyqtSlot
 from PyQt5 import QtWidgets
 
 # other non  user imports
@@ -12,6 +13,9 @@ class WritingControl(QtWidgets.QWidget):
 
     Most of the UI is copied from MATTER, but the Python implementation in this
     class is new."""
+
+    maraschino = "#ff2600"
+    moss = "#008f00"
 
     def __init__(self, parent, host, client):
         QtWidgets.QWidget.__init__(self, parent)
@@ -27,6 +31,9 @@ class WritingControl(QtWidgets.QWidget):
         self.writingStartButton.pressed.connect(self.startstop)
         self.writingCommentsButton.pressed.connect(self.comment)
         self.writingPauseButton.clicked.connect(self.pause)
+        self.checkBox_LJH22.clicked.connect(self.updateWritingActiveMessages)
+        self.checkBox_OFF.clicked.connect(self.updateWritingActiveMessages)
+
         cbd = self.changeBaseDirectoryButton
         if host == "localhost" or host == "127.0.0.1":
             cbd.pressed.connect(self.pathSelect)
@@ -107,6 +114,7 @@ class WritingControl(QtWidgets.QWidget):
         self.fileNameExampleEdit.setText("-")
         self.writingCommentsButton.setEnabled(False)
         self.writingPauseButton.setEnabled(False)
+        self.updateWritingActiveMessages()
 
     def startedWriting(self, exampleFilename):
         print("STARTED WRITING")
@@ -115,6 +123,21 @@ class WritingControl(QtWidgets.QWidget):
         self.fileNameExampleEdit.setText(exampleFilename)
         self.writingCommentsButton.setEnabled(True)
         self.writingPauseButton.setEnabled(True)
+        self.updateWritingActiveMessages()
+
+    @pyqtSlot()
+    def updateWritingActiveMessages(self):
+        labels = (self.label_LJH22, self.label_OFF)
+        checks = (self.checkBox_LJH22, self.checkBox_OFF)
+        for (label, check) in zip(labels, checks):
+            if self.writing and check.isChecked():
+                label.setText("Writing active")
+                color = self.moss
+            else:
+                label.setText("Not writing")
+                color = self.maraschino
+            ss = f"QLabel {{ color : {color}; }}"
+            label.setStyleSheet(ss)
 
     def pause(self, paused):
         request = "Pause"


### PR DESCRIPTION
This is a feature request from the HOLMES team: add GUI element(s) that will let one specify a max number of pulses to write to disk (summed over all sensors in the array). It is intended to help you keep from filling up your disk.
* Fixes #133
* Adds GUI messages on the writing tab that are red/green when not writing/writing for instant status.
* Relabels the triggering tabs as "Legacy Trigger" and "New Trigger"