### PR TITLE
Auto trigger veto

### DIFF
--- a/dastardcommander/trigger_config.py
+++ b/dastardcommander/trigger_config.py
@@ -443,6 +443,18 @@ class TriggerConfig(QtWidgets.QWidget):
             newstate["AutoDelay"] = nsdelay
         except ValueError:
             pass
+
+        # Check the auto veto level spin box. Turn text black if 0, red otherwise.
+        if self.autoVetoRange.value() == 0:
+            color = "black"
+            prefix = "Veto off:  "
+        else:
+            color = "red"
+            prefix = "Veto on:  "
+        ss = f"QSpinBox {{ color : {color}; }}"
+        self.autoVetoRange.setStyleSheet(ss)
+        self.autoVetoRange.setPrefix(prefix)
+
         self.setstates(newstate)
         self.configureDastardTriggers()
 

--- a/dastardcommander/trigger_config.py
+++ b/dastardcommander/trigger_config.py
@@ -278,6 +278,11 @@ class TriggerConfig(QtWidgets.QWidget):
                 continue
             edit.setText("%f" % (state * scale))
 
+        # Get the Auto Veto Level right
+        avr = self.getstate("AutoVetoRange")
+        if avr is not None:
+            self.autoVetoRange.setValue(avr)
+
         # Get the rising/falling/both/mixed state correct
         for (riseFallComboBox, rising, falling) in (
             (self.levelRiseFallBoth, "LevelRising", "LevelFalling"),
@@ -445,7 +450,9 @@ class TriggerConfig(QtWidgets.QWidget):
             pass
 
         # Check the auto veto level spin box. Turn text black if 0, red otherwise.
-        if self.autoVetoRange.value() == 0:
+        avr = self.autoVetoRange.value()
+        newstate["autoVetoRange"] = avr
+        if avr == 0:
             color = "black"
             prefix = "Veto off:  "
         else:

--- a/dastardcommander/ui/trigger_config.ui
+++ b/dastardcommander/ui/trigger_config.ui
@@ -648,6 +648,22 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="autoVetoRange">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Veto auto trigger records when [max-min] larger than this (or 0 to never veto).&lt;/p&gt;&lt;p&gt;Use non-zero values for recording pulse-free noise data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="prefix">
+         <string>Veto off:  </string>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -890,8 +906,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedAutoTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>163</x>
-     <y>382</y>
+     <x>161</x>
+     <y>370</y>
     </hint>
     <hint type="destinationlabel">
      <x>138</x>
@@ -906,8 +922,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedAutoTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>496</x>
-     <y>382</y>
+     <x>660</x>
+     <y>370</y>
     </hint>
     <hint type="destinationlabel">
      <x>419</x>
@@ -922,8 +938,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedLevelTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>163</x>
-     <y>408</y>
+     <x>161</x>
+     <y>399</y>
     </hint>
     <hint type="destinationlabel">
      <x>106</x>
@@ -938,8 +954,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedLevelTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>496</x>
-     <y>409</y>
+     <x>660</x>
+     <y>399</y>
     </hint>
     <hint type="destinationlabel">
      <x>328</x>
@@ -954,8 +970,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedEdgeTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>496</x>
-     <y>441</y>
+     <x>660</x>
+     <y>434</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -970,8 +986,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedEdgeTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>289</x>
-     <y>445</y>
+     <x>299</x>
+     <y>441</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -986,8 +1002,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedEdgeTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>163</x>
-     <y>432</y>
+     <x>161</x>
+     <y>425</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -1002,8 +1018,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedEdgeTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>163</x>
-     <y>451</y>
+     <x>161</x>
+     <y>444</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -1018,8 +1034,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedRecordLength(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>86</x>
-     <y>54</y>
+     <x>81</x>
+     <y>51</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -1066,8 +1082,8 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedLevelTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>289</x>
-     <y>412</y>
+     <x>299</x>
+     <y>406</y>
     </hint>
     <hint type="destinationlabel">
      <x>308</x>
@@ -1082,12 +1098,28 @@ the corresponding Error chan (Lancero only).</string>
    <slot>changedLevelUnits()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>559</x>
-     <y>471</y>
+     <x>778</x>
+     <y>347</y>
     </hint>
     <hint type="destinationlabel">
      <x>447</x>
      <y>484</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>autoVetoRange</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>triggerConfigTab</receiver>
+   <slot>changedAutoTrigConfig()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>239</x>
+     <y>364</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>305</y>
     </hint>
    </hints>
   </connection>

--- a/dastardcommander/ui/trigger_config.ui
+++ b/dastardcommander/ui/trigger_config.ui
@@ -651,7 +651,7 @@
       <item row="1" column="2">
        <widget class="QSpinBox" name="autoVetoRange">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Veto auto trigger records when [max-min] larger than this (or 0 to never veto).&lt;/p&gt;&lt;p&gt;Use non-zero values for recording pulse-free noise data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Veto auto trigger records when [max-min] larger than this (or set 0 to never veto).&lt;/p&gt;&lt;p&gt;Use non-zero values to record pulse-free noise data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>


### PR DESCRIPTION
Add GUI controls for the new feature where auto-triggers are (potentially) vetoed if the (max-min) is larger than a specified threshold. Fixes #132.