### PR TITLE
convert trigger length to int before sending it to spinbox

### DIFF
--- a/dastardcommander/trigger_config_simple.py
+++ b/dastardcommander/trigger_config_simple.py
@@ -78,7 +78,7 @@ class TriggerConfigSimple(QtWidgets.QWidget):
     def handleRecordLengthOrPercentPretrigChange(self):
         rl = self.spinBox_recordLength.value()
         percent = self.spinBox_percentPretrigger.value()
-        pt = rl * percent / 100
+        pt = int(rl * percent / 100)
         self.spinBox_pretrigLength.blockSignals(True)
         self.spinBox_pretrigLength.setValue(pt)
         self.spinBox_pretrigLength.blockSignals(False)


### PR DESCRIPTION
Prevents a crash when the pretrigger length ends up fractional when simply multiplying the pretrigger percent by the record length.