### PR TITLE
Make the Dcom window be less vertical; fix a text width problem

### DIFF
--- a/dastardcommander/dc.py
+++ b/dastardcommander/dc.py
@@ -97,7 +97,7 @@ class MainWindow(QtWidgets.QMainWindow):  # noqa: PLR0904
 
         QtWidgets.QMainWindow.__init__(self, parent)
         my_dir = os.path.dirname(__file__)
-        self.setWindowIcon(QtGui.QIcon(os.path.join(my_dir,"ui/dc.png")))
+        self.setWindowIcon(QtGui.QIcon(os.path.join(my_dir, "ui/dc.png")))
         PyQt5.uic.loadUi(os.path.join(my_dir, "ui/dc.ui"), self)
 
         short_ver = __version__.split("+")[0]
@@ -952,7 +952,7 @@ class MainWindow(QtWidgets.QMainWindow):  # noqa: PLR0904
         chansep_cards = 0
         firstrow = 1
         if self.channels0button.isChecked():
-            firstrow=0
+            firstrow = 0
         if self.channels1kcardbutton.isChecked():
             chansep_cards = 1000
         if self.channels10kcard1kcolButton.isChecked():

--- a/dastardcommander/observe.py
+++ b/dastardcommander/observe.py
@@ -109,7 +109,6 @@ class Observe(QtWidgets.QWidget):
         )
         self.blocklist_changed.connect(self.updateDisabledCount)
 
-
     blocklist_changed = pyqtSignal()
     block_channel = pyqtSignal(int)
 
@@ -239,11 +238,11 @@ class Observe(QtWidgets.QWidget):
                 continue
             map.enableAllChannels()
 
-    @pyqtSlot()    
+    @pyqtSlot()
     def updateDisabledCount(self):
         ndisabled = len(self.triggerBlocker.special)
-        n = len(self.channel_names)    
-        nenabled = n-ndisabled    
+        n = len(self.channel_names)
+        nenabled = n - ndisabled
         msg = f"{ndisabled} disabled, {nenabled} enabled of {n} channels"
         self.label_disabled_count.setText(msg)
 

--- a/dastardcommander/ui/dc.ui
+++ b/dastardcommander/ui/dc.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>770</width>
-    <height>669</height>
+    <width>854</width>
+    <height>609</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -162,7 +162,7 @@
         <item>
          <widget class="QStackedWidget" name="dataSourcesStackedWidget">
           <property name="currentIndex">
-           <number>2</number>
+           <number>4</number>
           </property>
           <widget class="QWidget" name="trianglePage">
            <layout class="QGridLayout" name="gridLayout_7">
@@ -1090,210 +1090,6 @@
           </widget>
           <widget class="QWidget" name="abacoPage">
            <layout class="QGridLayout" name="gridLayout_11">
-            <item row="0" column="1">
-             <widget class="QFrame" name="frame_2">
-              <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
-              </property>
-              <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_10">
-               <item>
-                <widget class="QLabel" name="label_32">
-                 <property name="font">
-                  <font>
-                   <pointsize>14</pointsize>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Phase unwrapping</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="unwrapBiasCheck">
-                 <property name="text">
-                  <string>Biased unwrapping?</string>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="phasePosPulses">
-                 <property name="text">
-                  <string>Pulses are positive</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="phaseNegPulses">
-                 <property name="text">
-                  <string>Pulses are negative</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="biasTextLabel">
-                 <property name="text">
-                  <string>No bias: [-.50, +.50]</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="verticalSpacer_3">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QLabel" name="resetAfterLabel">
-                 <property name="text">
-                  <string>Reset after:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QFormLayout" name="resetAfterLayout">
-                 <item row="0" column="0">
-                  <widget class="QSpinBox" name="phaseResetSamplesBox">
-                   <property name="toolTip">
-                    <string>Phase unwrap resets to near-zero after this many samples</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                   <property name="minimum">
-                    <number>10</number>
-                   </property>
-                   <property name="maximum">
-                    <number>999999999</number>
-                   </property>
-                   <property name="value">
-                    <number>10000</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLabel" name="phaseResetSamplesLabel">
-                   <property name="text">
-                    <string>Samples</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QDoubleSpinBox" name="phaseResetMultiplierBox">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="toolTip">
-                    <string>Set Phase Unwrap Samples to be this multiple of the record length</string>
-                   </property>
-                   <property name="decimals">
-                    <number>4</number>
-                   </property>
-                   <property name="minimum">
-                    <double>1.000000000000000</double>
-                   </property>
-                   <property name="maximum">
-                    <double>999.990000000000009</double>
-                   </property>
-                   <property name="value">
-                    <double>10.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QLabel" name="phaseResetMultiplierLabel">
-                   <property name="text">
-                    <string>Records lengths</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QComboBox" name="comboBox_AbacoUnwrapEnable">
-                 <property name="toolTip">
-                  <string>Choose whether to unwrap µMUX data, or assume raw (non-µMUX) data</string>
-                 </property>
-                 <item>
-                  <property name="text">
-                   <string>Unwrap µMUX [normal]</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Never unwrap, but rescale µMUX</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Never unwrap or rescale (not µMUX)</string>
-                  </property>
-                 </item>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_26">
-                 <property name="text">
-                  <string>Inverted Channels:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QTextEdit" name="invertedChanTextEdit">
-                 <property name="enabled">
-                  <bool>false</bool>
-                 </property>
-                 <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Invert these channels (comma-separated list). &lt;/p&gt;&lt;p&gt;Use the Expert menu to enable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <spacer name="verticalSpacer_11">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="2">
-             <spacer name="horizontalSpacer_7">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
             <item row="0" column="0">
              <widget class="QFrame" name="abacoFrame">
               <property name="frameShape">
@@ -1510,6 +1306,222 @@
                   </size>
                  </property>
                 </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QFrame" name="frame_2">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_10">
+               <item>
+                <widget class="QLabel" name="label_32">
+                 <property name="font">
+                  <font>
+                   <pointsize>14</pointsize>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Phase unwrapping</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="unwrapBiasCheck">
+                 <property name="text">
+                  <string>Biased unwrapping?</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="phasePosPulses">
+                 <property name="text">
+                  <string>Pulses are positive</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="phaseNegPulses">
+                 <property name="text">
+                  <string>Pulses are negative</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="biasTextLabel">
+                 <property name="text">
+                  <string>No bias: [-.50, +.50]</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="resetAfterLabel">
+                 <property name="text">
+                  <string>Reset after:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <layout class="QFormLayout" name="resetAfterLayout">
+                 <item row="0" column="0">
+                  <widget class="QSpinBox" name="phaseResetSamplesBox">
+                   <property name="toolTip">
+                    <string>Phase unwrap resets to near-zero after this many samples</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   </property>
+                   <property name="minimum">
+                    <number>10</number>
+                   </property>
+                   <property name="maximum">
+                    <number>999999999</number>
+                   </property>
+                   <property name="value">
+                    <number>10000</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLabel" name="phaseResetSamplesLabel">
+                   <property name="text">
+                    <string>Samples</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QDoubleSpinBox" name="phaseResetMultiplierBox">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="toolTip">
+                    <string>Set Phase Unwrap Samples to be this multiple of the record length</string>
+                   </property>
+                   <property name="decimals">
+                    <number>4</number>
+                   </property>
+                   <property name="minimum">
+                    <double>1.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>999.990000000000009</double>
+                   </property>
+                   <property name="value">
+                    <double>10.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QLabel" name="phaseResetMultiplierLabel">
+                   <property name="text">
+                    <string>Records lengths</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QComboBox" name="comboBox_AbacoUnwrapEnable">
+                 <property name="toolTip">
+                  <string>Choose whether to unwrap µMUX data, or assume raw (non-µMUX) data</string>
+                 </property>
+                 <item>
+                  <property name="text">
+                   <string>Unwrap µMUX [normal]</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Never unwrap, but rescale µMUX</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Never unwrap or rescale (not µMUX)</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <spacer name="verticalSpacer_11">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="0" column="3">
+             <spacer name="horizontalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="0" column="2">
+             <widget class="QFrame" name="frame_3">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_11">
+               <item>
+                <widget class="QLabel" name="label_26">
+                 <property name="text">
+                  <string>Inverted Channels:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QTextEdit" name="invertedChanTextEdit">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Invert these channels (comma-separated list). &lt;/p&gt;&lt;p&gt;Use the Expert menu to enable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -1862,8 +1874,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>770</width>
-     <height>22</height>
+     <width>854</width>
+     <height>37</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuConnection">

--- a/dastardcommander/ui/trigger_config.ui
+++ b/dastardcommander/ui/trigger_config.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>788</width>
-    <height>688</height>
+    <width>802</width>
+    <height>528</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -39,21 +39,27 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QFrame" name="recordSizeFrame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="frameShape">
         <enum>QFrame::Panel</enum>
        </property>
        <layout class="QGridLayout" name="recordDetailLayout">
         <property name="leftMargin">
-         <number>3</number>
+         <number>12</number>
         </property>
         <property name="topMargin">
-         <number>3</number>
+         <number>6</number>
         </property>
         <property name="rightMargin">
-         <number>3</number>
+         <number>12</number>
         </property>
         <property name="bottomMargin">
-         <number>3</number>
+         <number>6</number>
         </property>
         <property name="horizontalSpacing">
          <number>6</number>
@@ -61,33 +67,17 @@
         <property name="verticalSpacing">
          <number>4</number>
         </property>
-        <item row="2" column="1">
-         <widget class="QLabel" name="pretrigLengthLabel">
-          <property name="text">
-           <string>Pretrigger samples</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0" colspan="2">
-         <widget class="QLabel" name="label_19">
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="text">
-           <string>Record size</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="1">
          <widget class="QLabel" name="recordLengthLabel">
           <property name="text">
            <string>Samples per record</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="pretrigLengthLabel">
+          <property name="text">
+           <string>Pretrigger samples</string>
           </property>
          </widget>
         </item>
@@ -119,6 +109,19 @@
            <string>% Pretrigger</string>
           </property>
          </widget>
+        </item>
+        <item row="4" column="1">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>10</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item row="2" column="0">
          <widget class="QSpinBox" name="pretrigLengthSpinBox">
@@ -155,174 +158,182 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+        <item row="0" column="0" colspan="2">
+         <widget class="QLabel" name="label_19">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
+          <property name="text">
+           <string>Record size</string>
           </property>
-         </spacer>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="channelsChosenLayout">
-       <property name="leftMargin">
-        <number>2</number>
+      <widget class="QFrame" name="horizontalFrame_2">
+       <property name="frameShape">
+        <enum>QFrame::Panel</enum>
        </property>
-       <property name="topMargin">
-        <number>2</number>
-       </property>
-       <property name="rightMargin">
-        <number>2</number>
-       </property>
-       <property name="bottomMargin">
-        <number>2</number>
-       </property>
-       <item>
-        <widget class="QFrame" name="horizontalFrame_2">
-         <property name="frameShape">
-          <enum>QFrame::Panel</enum>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_4" columnstretch="2,1">
-          <item row="1" column="0">
-           <widget class="QPlainTextEdit" name="channelsChosenEdit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-              <horstretch>2</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>160</width>
-              <height>20</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="sizeIncrement">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="baseSize">
-             <size>
-              <width>160</width>
-              <height>10</height>
-             </size>
-            </property>
-            <property name="tabChangesFocus">
-             <bool>true</bool>
-            </property>
-           </widget>
+       <layout class="QGridLayout" name="gridLayout_4" columnstretch="2,0">
+        <property name="leftMargin">
+         <number>12</number>
+        </property>
+        <property name="topMargin">
+         <number>6</number>
+        </property>
+        <property name="rightMargin">
+         <number>12</number>
+        </property>
+        <property name="bottomMargin">
+         <number>6</number>
+        </property>
+        <item row="1" column="0">
+         <widget class="QPlainTextEdit" name="channelsChosenEdit">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>160</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeIncrement">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>160</width>
+            <height>10</height>
+           </size>
+          </property>
+          <property name="tabChangesFocus">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QComboBox" name="channelChooserBox">
+          <property name="toolTip">
+           <string>Fill the channel list (above) with standard groupings</string>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>user defined</string>
+           </property>
           </item>
-          <item row="1" column="1">
-           <widget class="QPlainTextEdit" name="disabledTextEdit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>1</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="baseSize">
-             <size>
-              <width>100</width>
-              <height>10</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Channels not allowed to trigger (toggle single channels in Observe tab)</string>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="plainText">
-             <string>All channels are enabled</string>
-            </property>
-           </widget>
+          <item>
+           <property name="text">
+            <string>All channels</string>
+           </property>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="channelsChosenLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Channels chosen:</string>
-            </property>
-           </widget>
+          <item>
+           <property name="text">
+            <string>Signal channels</string>
+           </property>
           </item>
-          <item row="2" column="0">
-           <widget class="QComboBox" name="channelChooserBox">
-            <property name="toolTip">
-             <string>Fill the channel list (above) with standard groupings</string>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <item>
-             <property name="text">
-              <string>user defined</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>All channels</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Signal channels</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>TDM error channels</string>
-             </property>
-            </item>
-           </widget>
+          <item>
+           <property name="text">
+            <string>TDM error channels</string>
+           </property>
           </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="clearDisabledButton">
-            <property name="toolTip">
-             <string>Clear the list of disabled channels</string>
-            </property>
-            <property name="text">
-             <string>Enable all channels</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="disable_label">
-            <property name="text">
-             <string>Disabled channels (never trigger):</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QPlainTextEdit" name="disabledTextEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>100</width>
+            <height>10</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Channels not allowed to trigger (toggle single channels in Observe tab)</string>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="plainText">
+           <string>All channels are enabled</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QPushButton" name="clearDisabledButton">
+          <property name="toolTip">
+           <string>Clear the list of disabled channels</string>
+          </property>
+          <property name="text">
+           <string>Enable all channels</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="disable_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Disabled channels (never trigger):</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="channelsChosenLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Channels chosen:</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </item>
     </layout>
    </item>
@@ -830,60 +841,15 @@
         </item>
        </layout>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Group Triggering</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="groupTriggerActiveSrc">
-          <property name="text">
-           <string>Active group trigger sources: &lt;none&gt;</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="groupTriggerActiveRx">
-          <property name="text">
-           <string>Active group trigger receivers: &lt;none&gt;</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="7" column="0">
-       <layout class="QGridLayout" name="couplingGridLayout" columnstretch="0,0" columnminimumwidth="0,0">
+      <item row="6" column="0">
+       <layout class="QGridLayout" name="couplingGridLayout" columnstretch="3,1" columnminimumwidth="0,0">
         <property name="topMargin">
          <number>2</number>
         </property>
         <property name="bottomMargin">
          <number>2</number>
         </property>
-        <item row="0" column="0">
-         <widget class="QCheckBox" name="coupleFBToErrCheckBox">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>If checked, any trigger in a FB channel will also trigger
-the corresponding Error chan (Lancero only).</string>
-          </property>
-          <property name="text">
-           <string>Couple Feedback --&gt; Error (for SQUID checking)</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
+        <item row="1" column="1">
          <widget class="QCheckBox" name="coupleErrToFBCheckBox">
           <property name="enabled">
            <bool>false</bool>
@@ -897,7 +863,35 @@ trigger the corresponding FB chan (Lancero only).</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="coupleFBToErrCheckBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>If checked, any trigger in a FB channel will also trigger
+the corresponding Error chan (Lancero only).</string>
+          </property>
+          <property name="text">
+           <string>Couple Feedback --&gt; Error (SQUID checks)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="groupTriggerActiveRx">
+          <property name="text">
+           <string>Active group trigger receivers: &lt;none&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="groupTriggerActiveSrc">
+          <property name="text">
+           <string>Active group trigger sources: &lt;none&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
          <widget class="QPushButton" name="groupTriggerClearAll">
           <property name="text">
            <string>Clear all group triggers and coupling</string>
@@ -905,6 +899,16 @@ trigger the corresponding FB chan (Lancero only).</string>
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Group Triggering</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -925,8 +929,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedAutoTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>161</x>
-     <y>370</y>
+     <x>175</x>
+     <y>267</y>
     </hint>
     <hint type="destinationlabel">
      <x>138</x>
@@ -941,8 +945,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedAutoTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>660</x>
-     <y>370</y>
+     <x>471</x>
+     <y>267</y>
     </hint>
     <hint type="destinationlabel">
      <x>419</x>
@@ -957,8 +961,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedLevelTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>161</x>
-     <y>399</y>
+     <x>175</x>
+     <y>296</y>
     </hint>
     <hint type="destinationlabel">
      <x>106</x>
@@ -973,8 +977,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedLevelTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>660</x>
-     <y>399</y>
+     <x>471</x>
+     <y>296</y>
     </hint>
     <hint type="destinationlabel">
      <x>328</x>
@@ -989,8 +993,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedEdgeTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>660</x>
-     <y>434</y>
+     <x>471</x>
+     <y>331</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -1005,8 +1009,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedEdgeTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>299</x>
-     <y>441</y>
+     <x>298</x>
+     <y>338</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -1021,8 +1025,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedEdgeTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>161</x>
-     <y>425</y>
+     <x>175</x>
+     <y>322</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -1037,8 +1041,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedEdgeTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>161</x>
-     <y>444</y>
+     <x>175</x>
+     <y>341</y>
     </hint>
     <hint type="destinationlabel">
      <x>299</x>
@@ -1101,8 +1105,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedLevelTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>299</x>
-     <y>406</y>
+     <x>298</x>
+     <y>303</y>
     </hint>
     <hint type="destinationlabel">
      <x>308</x>
@@ -1117,8 +1121,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedLevelUnits()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>778</x>
-     <y>347</y>
+     <x>589</x>
+     <y>244</y>
     </hint>
     <hint type="destinationlabel">
      <x>447</x>
@@ -1133,8 +1137,8 @@ trigger the corresponding FB chan (Lancero only).</string>
    <slot>changedAutoTrigConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>239</x>
-     <y>364</y>
+     <x>295</x>
+     <y>267</y>
     </hint>
     <hint type="destinationlabel">
      <x>217</x>

--- a/dastardcommander/ui/trigger_config.ui
+++ b/dastardcommander/ui/trigger_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>788</width>
-    <height>739</height>
+    <height>688</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -327,345 +327,429 @@
     </layout>
    </item>
    <item>
-    <widget class="QFrame" name="triggerDetailsGroup">
-     <property name="enabled">
-      <bool>true</bool>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="topMargin">
+      <number>10</number>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>6</number>
-      </property>
-      <property name="rightMargin">
-       <number>6</number>
-      </property>
-      <property name="bottomMargin">
-       <number>6</number>
-      </property>
-      <property name="verticalSpacing">
-       <number>6</number>
-      </property>
-      <item row="5" column="0" rowspan="2">
-       <widget class="QLabel" name="edgeTrigLabel">
-        <property name="text">
-         <string>Edge trigger</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="margin">
-         <number>2</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="4" rowspan="2">
-       <widget class="QLabel" name="edgeUnitsLabel">
-        <property name="text">
-         <string>raw/samp</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="3" rowspan="2">
-       <widget class="QLineEdit" name="edgeEdit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>10</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="baseSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Slope threshhold, in Volts/ms.</string>
-        </property>
-        <property name="text">
-         <string>1</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QLineEdit" name="autoTimeEdit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>10</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="baseSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Time between auto triggers (ms)</string>
-        </property>
-        <property name="text">
-         <string>1000</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="autoTrigLabel">
-        <property name="text">
-         <string>Auto trigger</string>
-        </property>
-        <property name="margin">
-         <number>2</number>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QCheckBox" name="spikeReject">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Whether to use the spike-rejection test in the edge trigger algorithm</string>
-        </property>
-        <property name="text">
-         <string>Spike</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QComboBox" name="levelRiseFallBoth">
-        <item>
-         <property name="text">
-          <string>Rising edge</string>
-         </property>
+     <item>
+      <widget class="QFrame" name="frame">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_5">
+        <item row="0" column="0">
+         <widget class="QFrame" name="triggerDetailsGroup">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="leftMargin">
+            <number>6</number>
+           </property>
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <property name="rightMargin">
+            <number>6</number>
+           </property>
+           <property name="bottomMargin">
+            <number>6</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>6</number>
+           </property>
+           <item row="2" column="4">
+            <widget class="QLabel" name="levelUnitsLabel">
+             <property name="text">
+              <string>raw</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QComboBox" name="levelRiseFallBoth">
+             <item>
+              <property name="text">
+               <string>Rising edge</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Falling edge</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Either</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>(-mixed-)</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>Direction</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Trigger Type</string>
+             </property>
+             <property name="margin">
+              <number>-1</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QCheckBox" name="levelTrigActive">
+             <property name="toolTip">
+              <string>Turn on level trigger for selected channels</string>
+             </property>
+             <property name="text">
+              <string>Active</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Active?</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QCheckBox" name="autoTrigActive">
+             <property name="toolTip">
+              <string>Turn on auto-trigger for selected channels</string>
+             </property>
+             <property name="text">
+              <string>Active</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QLineEdit" name="autoTimeEdit">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>10</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Time between auto triggers (ms)</string>
+             </property>
+             <property name="text">
+              <string>1000</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3" rowspan="2">
+            <widget class="QLineEdit" name="levelEdit">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>10</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Raw or voltage level for the level trigger</string>
+             </property>
+             <property name="text">
+              <string>0.5</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="4">
+            <widget class="QLabel" name="autoUnitsLabel">
+             <property name="text">
+              <string>ms</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0" rowspan="2">
+            <widget class="QLabel" name="edgeTrigLabel">
+             <property name="text">
+              <string>Edge trigger</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+             <property name="margin">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Trigger threshold</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" rowspan="2">
+            <widget class="QLabel" name="levelTrigLabel">
+             <property name="text">
+              <string>Level trigger</string>
+             </property>
+             <property name="margin">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="autoTrigLabel">
+             <property name="text">
+              <string>Auto trigger</string>
+             </property>
+             <property name="margin">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="4">
+            <widget class="QComboBox" name="levelVoltsRaw">
+             <property name="toolTip">
+              <string>Change units for trigger thresholds</string>
+             </property>
+             <property name="currentIndex">
+              <number>1</number>
+             </property>
+             <item>
+              <property name="text">
+               <string>Volts</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Raw units</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="5" column="3" rowspan="2">
+            <widget class="QLineEdit" name="edgeEdit">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>10</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Slope threshhold, in Volts/ms.</string>
+             </property>
+             <property name="text">
+              <string>1</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QSpinBox" name="autoVetoRange">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Veto auto trigger records when [max-min] larger than this (or set 0 to never veto).&lt;/p&gt;&lt;p&gt;Use non-zero values to record pulse-free noise data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+             <property name="prefix">
+              <string>Veto off:  </string>
+             </property>
+             <property name="maximum">
+              <number>65535</number>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QCheckBox" name="spikeReject">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="toolTip">
+              <string>Whether to use the spike-rejection test in the edge trigger algorithm</string>
+             </property>
+             <property name="text">
+              <string>Spike</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="2" rowspan="2">
+            <widget class="QComboBox" name="edgeRiseFallBoth">
+             <property name="toolTip">
+              <string>Trigger these channels on rising edges, falling edges, or both</string>
+             </property>
+             <item>
+              <property name="text">
+               <string>Rising edge</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Falling edge</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Either</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>(-mixed-)</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="5" column="4" rowspan="2">
+            <widget class="QLabel" name="edgeUnitsLabel">
+             <property name="text">
+              <string>raw/samp</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QCheckBox" name="edgeTrigActive">
+             <property name="toolTip">
+              <string>Turn on edge trigger for selected channels</string>
+             </property>
+             <property name="text">
+              <string>Active</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>Falling edge</string>
-         </property>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QFrame" name="triggerLoadSaveFrame">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::Panel</enum>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <property name="topMargin">
+         <number>6</number>
+        </property>
+        <property name="rightMargin">
+         <number>6</number>
+        </property>
+        <property name="bottomMargin">
+         <number>6</number>
+        </property>
+        <item row="3" column="1">
+         <widget class="QPushButton" name="pulseModeButton">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Switch to pulse data mode
+(keep same edge threshold)</string>
+          </property>
+          <property name="text">
+           <string>Pulse Mode</string>
+          </property>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>Either</string>
-         </property>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="noiseModeButton">
+          <property name="toolTip">
+           <string>Switch to noise data mode</string>
+          </property>
+          <property name="text">
+           <string>Noise Mode</string>
+          </property>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>(-mixed-)</string>
-         </property>
+        <item row="2" column="1">
+         <widget class="QPushButton" name="auto1psModeButton">
+          <property name="toolTip">
+           <string>Switch to auto data mode (1 trigger/second)</string>
+          </property>
+          <property name="text">
+           <string>Auto Mode (1/sec)</string>
+          </property>
+         </widget>
         </item>
-       </widget>
-      </item>
-      <item row="2" column="3" rowspan="2">
-       <widget class="QLineEdit" name="levelEdit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>10</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="baseSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Raw or voltage level for the level trigger</string>
-        </property>
-        <property name="text">
-         <string>0.5</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <widget class="QLabel" name="autoUnitsLabel">
-        <property name="text">
-         <string>ms</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="levelTrigActive">
-        <property name="toolTip">
-         <string>Turn on level trigger for selected channels</string>
-        </property>
-        <property name="text">
-         <string>Active</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="2" rowspan="2">
-       <widget class="QComboBox" name="edgeRiseFallBoth">
-        <property name="toolTip">
-         <string>Trigger these channels on rising edges, falling edges, or both</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Rising edge</string>
-         </property>
+        <item row="0" column="1">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Quick modes:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
         </item>
-        <item>
-         <property name="text">
-          <string>Falling edge</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Either</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>(-mixed-)</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QCheckBox" name="edgeTrigActive">
-        <property name="toolTip">
-         <string>Turn on edge trigger for selected channels</string>
-        </property>
-        <property name="text">
-         <string>Active</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" rowspan="2">
-       <widget class="QLabel" name="levelTrigLabel">
-        <property name="text">
-         <string>Level trigger</string>
-        </property>
-        <property name="margin">
-         <number>2</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <widget class="QLabel" name="levelUnitsLabel">
-        <property name="text">
-         <string>raw</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="autoTrigActive">
-        <property name="toolTip">
-         <string>Turn on auto-trigger for selected channels</string>
-        </property>
-        <property name="text">
-         <string>Active</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QComboBox" name="levelVoltsRaw">
-        <property name="toolTip">
-         <string>Change units for trigger thresholds</string>
-        </property>
-        <property name="currentIndex">
-         <number>1</number>
-        </property>
-        <item>
-         <property name="text">
-          <string>Volts</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Raw units</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Trigger Type</string>
-        </property>
-        <property name="margin">
-         <number>-1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Active?</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Trigger threshold</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Direction</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QSpinBox" name="autoVetoRange">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Veto auto trigger records when [max-min] larger than this (or set 0 to never veto).&lt;/p&gt;&lt;p&gt;Use non-zero values to record pulse-free noise data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="prefix">
-         <string>Veto off:  </string>
-        </property>
-        <property name="maximum">
-         <number>65535</number>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+       </layout>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QFrame" name="GroupTriggerFrame">
@@ -785,6 +869,20 @@
         <property name="bottomMargin">
          <number>2</number>
         </property>
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="coupleFBToErrCheckBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>If checked, any trigger in a FB channel will also trigger
+the corresponding Error chan (Lancero only).</string>
+          </property>
+          <property name="text">
+           <string>Couple Feedback --&gt; Error (for SQUID checking)</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="1">
          <widget class="QCheckBox" name="coupleErrToFBCheckBox">
           <property name="enabled">
@@ -806,86 +904,7 @@ trigger the corresponding FB chan (Lancero only).</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QCheckBox" name="coupleFBToErrCheckBox">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>If checked, any trigger in a FB channel will also trigger
-the corresponding Error chan (Lancero only).</string>
-          </property>
-          <property name="text">
-           <string>Couple Feedback --&gt; Error (for SQUID checking)</string>
-          </property>
-         </widget>
-        </item>
        </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QFrame" name="triggerLoadSaveFrame">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="topMargin">
-       <number>6</number>
-      </property>
-      <property name="rightMargin">
-       <number>6</number>
-      </property>
-      <property name="bottomMargin">
-       <number>6</number>
-      </property>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="pulseModeButton">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Switch to pulse data mode
-(keep same edge threshold)</string>
-        </property>
-        <property name="text">
-         <string>Pulse Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="auto1psModeButton">
-        <property name="toolTip">
-         <string>Switch to auto data mode (1 trigger/second)</string>
-        </property>
-        <property name="text">
-         <string>Auto Mode (1/sec)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="noiseModeButton">
-        <property name="toolTip">
-         <string>Switch to noise data mode</string>
-        </property>
-        <property name="text">
-         <string>Noise Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Quick modes:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>

--- a/dastardcommander/writing.py
+++ b/dastardcommander/writing.py
@@ -80,8 +80,17 @@ class WritingControl(QtWidgets.QWidget):
             written_message += f" ({pct:.2f}% of the automatic shutoff value)"
             if Nmax > 0 and Nwritten >= Nmax and self.writing:
                 self.stop()
-        self.label_numberWritten.setText("Number Written Total: {}\nNumber Written by Channel: {}".format(
-            written_message, d["NumberWritten"]))
+
+        labeltext = [f"Number Written Total: {written_message}",
+                     "Number Written by Channel:"]
+        nw = d["NumberWritten"]
+        nitems = len(nw)
+        nperline = 16
+        for i in range(1 + (nitems-1) // nperline):
+            items = " ".join([f"{x:6d}" for x in nw[nperline*i:nperline*(i+1)]])
+            labeltext.append(f"\t{items}")
+        print(labeltext)
+        self.label_numberWritten.setText("\n".join(labeltext))
 
     def start(self):
         if self.writing:

--- a/dastardcommander/writing.py
+++ b/dastardcommander/writing.py
@@ -89,7 +89,6 @@ class WritingControl(QtWidgets.QWidget):
         for i in range(1 + (nitems-1) // nperline):
             items = " ".join([f"{x:6d}" for x in nw[nperline*i:nperline*(i+1)]])
             labeltext.append(f"\t{items}")
-        print(labeltext)
         self.label_numberWritten.setText("\n".join(labeltext))
 
     def start(self):


### PR DESCRIPTION
Makes the classic trigger widget, and thus the entire window, not quite as tall.
Fixes #137, even though I could not reproduce the problem on a Mac.